### PR TITLE
fix leaf node measure function

### DIFF
--- a/packages/nativescript-masonkit/src-native/mason-android/app/build.gradle
+++ b/packages/nativescript-masonkit/src-native/mason-android/app/build.gradle
@@ -13,7 +13,7 @@ android {
     targetSdk 33
     versionCode 1
     versionName "1.0"
-
+    multiDexEnabled true
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 
@@ -49,4 +49,5 @@ dependencies {
   testImplementation 'junit:junit:4.13.2'
   androidTestImplementation 'androidx.test.ext:junit:1.1.4'
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
+  implementation 'androidx.multidex:multidex:2.0.1'
 }

--- a/packages/nativescript-masonkit/src-native/mason-android/masonkit/src/main/java/org/nativescript/mason/masonkit/View.kt
+++ b/packages/nativescript-masonkit/src-native/mason-android/masonkit/src/main/java/org/nativescript/mason/masonkit/View.kt
@@ -125,13 +125,13 @@ class View @JvmOverloads constructor(
         return
       }
 
-      val layout = node.layout()
+      var layout = node.layout()
 
       var widthIsNaN = layout.width.isNaN()
       var heightIsNaN = layout.height.isNaN()
 
-      val measureWidth = if (widthIsNaN) 0 else layout.width.roundToInt()
-      val measureHeight = if (heightIsNaN) 0 else layout.height.roundToInt()
+      var measureWidth = if (widthIsNaN) 0 else layout.width.roundToInt()
+      var measureHeight = if (heightIsNaN) 0 else layout.height.roundToInt()
 
       if (measureWidth == 0 && node.style.size.width == Dimension.Auto) {
         widthIsNaN = true
@@ -140,7 +140,6 @@ class View @JvmOverloads constructor(
       if (measureHeight == 0 && node.style.size.height == Dimension.Auto) {
         heightIsNaN = true
       }
-
 
       if (widthIsNaN || heightIsNaN) {
         view.measure(
@@ -153,7 +152,6 @@ class View @JvmOverloads constructor(
           )
         )
       }
-
 
       val left = (xOffset + if (layout.x.isNaN()) 0F else layout.x).roundToInt()
       val top = (yOffset + if (layout.y.isNaN()) 0F else layout.y).roundToInt()
@@ -262,7 +260,7 @@ class View @JvmOverloads constructor(
 
   override fun addView(child: android.view.View, index: Int, params: ViewGroup.LayoutParams) {
     node.removeMeasureFunction()
-    super.addView(child, index, params)
+    super.addView(child, index, params);
 
     if (nodes.containsKey(child)) {
       return
@@ -1840,66 +1838,49 @@ class View @JvmOverloads constructor(
 
       node.get()?.let { node ->
 
-        var widthCalculated = false
-        var heightCalculated = false
-
         var isWidthPercent = false
         var isHeightPercent = false
 
-        if (widthIsNaN) {
+        if (widthIsNaN || width.equals(0.0f)) {
           if (node.style.size.width is Dimension.Points) {
             retWidth = node.style.size.width.value
-            widthCalculated = true
           } else if (node.style.size.width is Dimension.Percent) {
-            isWidthPercent = true
+            isHeightPercent = true;
           }
         }
 
-        if (heightIsNaN) {
+        if (heightIsNaN || height.equals(0.0f)) {
           if (node.style.size.height is Dimension.Points) {
             retHeight = node.style.size.height.value
-            heightCalculated = true
           } else if (node.style.size.height is Dimension.Percent) {
-            isHeightPercent = true
+            isHeightPercent = true;
           }
         }
-
-        if (widthCalculated && heightCalculated) {
-          return@let
-        }
-
-        val measureWidth = if (widthIsNaN) 0 else width.roundToInt()
-        val measureHeight = if (heightIsNaN) 0 else height.roundToInt()
-
-        val widthSpec = if (widthIsNaN) MeasureSpec.UNSPECIFIED else MeasureSpec.EXACTLY
-
-        val heightSpec = if (heightIsNaN) MeasureSpec.UNSPECIFIED else MeasureSpec.EXACTLY
 
         view.measure(
           MeasureSpec.makeMeasureSpec(
-            measureWidth, widthSpec
+            retWidth.roundToInt(), MeasureSpec.EXACTLY
           ), MeasureSpec.makeMeasureSpec(
-            measureHeight, heightSpec
+            retHeight.roundToInt(), MeasureSpec.EXACTLY
           )
         )
 
         if (widthIsNaN) {
           retWidth = view.measuredWidth.toFloat()
-          if (retWidth == 0F) {
+          if (retWidth.equals(0f)) {
             retWidth = Float.NaN
           }
         }
 
         if (heightIsNaN) {
           retHeight = view.measuredHeight.toFloat()
-          if (retHeight == 0F) {
+          if (retHeight.equals(0f)) {
             retHeight = Float.NaN
           }
         }
       }
 
       return Size(retWidth, retHeight)
-
     }
 
     override fun measure(


### PR DESCRIPTION
all leaf nodes that are not masonkit View must call `view.measure` in `ViewMeasureFunc` to ensure that they & their children are laid our correctly.