### PR TITLE
android: fix measuring root node views

### DIFF
--- a/packages/nativescript-masonkit/src-native/mason-android/masonkit/src/main/java/org/nativescript/mason/masonkit/Node.kt
+++ b/packages/nativescript-masonkit/src-native/mason-android/masonkit/src/main/java/org/nativescript/mason/masonkit/Node.kt
@@ -55,7 +55,7 @@ class Node private constructor(private var nativePtr: Long) {
     }
 
     this.children.addAll(children)
-
+    
     this.style = style
   }
 

--- a/packages/nativescript-masonkit/src-native/mason-android/masonkit/src/main/java/org/nativescript/mason/masonkit/View.kt
+++ b/packages/nativescript-masonkit/src-native/mason-android/masonkit/src/main/java/org/nativescript/mason/masonkit/View.kt
@@ -294,10 +294,39 @@ class View @JvmOverloads constructor(
     }
 
     val layout = if (parent !is View) {
-      if (node.style.size.height is Dimension.Auto || node.style.size.width is Dimension.Auto) {
+      val mason_height = node.style.size.height
+      val mason_width = node.style.size.width
+
+      if (mason_width is Dimension.Auto && mason_height is Dimension.Auto) {
         node.computeMaxContent()
       } else {
-        node.computeAndLayout(specWidth.toFloat(), specHeight.toFloat())
+        var width = 0.0f;
+        var height = 0.0f;
+
+        when(mason_width) {
+          is Dimension.Percent -> {
+            width = mason_width.value * (parent as android.view.View).measuredWidth
+          }
+          is Dimension.Auto -> {
+              width = -2.0f
+          }
+          is Dimension.Points -> {
+            width = specWidth.toFloat();
+          }
+        }
+
+        when(mason_height) {
+          is Dimension.Percent -> {
+            height = mason_height.value * (parent as android.view.View).measuredHeight
+          }
+          is Dimension.Auto -> {
+            height = -2.0f
+          }
+          is Dimension.Points -> {
+            height = specHeight.toFloat();
+          }
+        }
+        node.compute(width,height);
       }
       node.layout()
     } else {

--- a/packages/nativescript-masonkit/src-native/mason-android/masonkit/src/main/java/org/nativescript/mason/masonkit/View.kt
+++ b/packages/nativescript-masonkit/src-native/mason-android/masonkit/src/main/java/org/nativescript/mason/masonkit/View.kt
@@ -281,6 +281,17 @@ class View @JvmOverloads constructor(
     shouldEnsureLayout = true;
   }
 
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+    if (this.parent !is View) {
+      this.node.dirty();
+      this.node.computeMaxContent();
+      val layout = this.node.layout();
+      this.layoutParams.width = if (layout.width.isNaN()) 0 else layout.width.toInt();
+      this.layoutParams.height = if (layout.height.isNaN()) 0 else layout.height.toInt();
+    }
+  }
+
   override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
     if (parent !is View) {
       createLayout(
@@ -353,7 +364,7 @@ class View @JvmOverloads constructor(
     setMeasuredDimension(
       width,
       height
-    )
+      )
   }
 
   override fun addView(child: android.view.View, index: Int, params: ViewGroup.LayoutParams) {

--- a/packages/nativescript-masonkit/src-native/mason-android/masonkit/src/main/java/org/nativescript/mason/masonkit/View.kt
+++ b/packages/nativescript-masonkit/src-native/mason-android/masonkit/src/main/java/org/nativescript/mason/masonkit/View.kt
@@ -44,7 +44,6 @@ class View @JvmOverloads constructor(
   context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
 ) : ViewGroup(context, attrs, defStyleAttr) {
 
-  var shouldEnsureLayout = true;
   var node = Node()
     private set
 
@@ -118,46 +117,6 @@ class View @JvmOverloads constructor(
     }
   }
 
-  private fun ensureLayout() {
-    if (!shouldEnsureLayout) return;
-    if (this.node.style.size.width !is Dimension.Auto && this.node.style.size.height !is Dimension.Auto) return
-    val layout = this.node.layout();
-
-    if (layout.width != 0f && layout.height != 0f) return
-    shouldEnsureLayout = false;
-    val width = if (layout.width.isNaN()) 0f else layout.width;
-    val height = if (layout.height.isNaN()) 0f else layout.height;
-    var bottom = if (layout.y.isNaN()) height else layout.y + height
-    var right = if (layout.x.isNaN()) width else layout.x + width
-
-    for (lt: Layout in layout.children) {
-      if (layout.width == 0f) {
-        right += lt.width
-      }
-      if (layout.height == 0f) {
-        bottom += lt.height
-      }
-    }
-    val correctParentWidth = (right - layout.x).toInt()
-    val correctParentHeight = (bottom - layout.y).toInt()
-    // If parent measured dim is same as parent layout dim, we can return safely.
-    if (this.measuredWidth != 0 &&
-      this.measuredHeight != 0 &&
-      correctParentWidth == this.measuredWidth &&
-      correctParentHeight == this.measuredHeight
-    ) return
-
-    this.measure(
-      MeasureSpec.makeMeasureSpec(correctParentWidth, MeasureSpec.EXACTLY),
-      MeasureSpec.makeMeasureSpec(correctParentHeight, MeasureSpec.EXACTLY)
-    )
-
-    this.layout(
-      layout.x.toInt(), layout.y.toInt(),
-      layout.x.toInt() + correctParentWidth, layout.y.toInt() + correctParentHeight
-    );
-  }
-
   private fun applyLayoutRecursive(node: Node, xOffset: Float, yOffset: Float) {
     val view = node.data as? android.view.View
 
@@ -228,11 +187,6 @@ class View @JvmOverloads constructor(
         heightIsNaN = false
       }
 
-      node.owner?.let {
-        val parent = it.data as View
-        if (parent !is View) return
-        parent.ensureLayout();
-      }
 
       if (widthIsNaN || heightIsNaN) {
         view.measure(
@@ -278,18 +232,6 @@ class View @JvmOverloads constructor(
         }
       }
     }
-    shouldEnsureLayout = true;
-  }
-
-  override fun onAttachedToWindow() {
-    super.onAttachedToWindow()
-    if (this.parent !is View) {
-      this.node.dirty();
-      this.node.computeMaxContent();
-      val layout = this.node.layout();
-      this.layoutParams.width = if (layout.width.isNaN()) 0 else layout.width.toInt();
-      this.layoutParams.height = if (layout.height.isNaN()) 0 else layout.height.toInt();
-    }
   }
 
   override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
@@ -300,9 +242,8 @@ class View @JvmOverloads constructor(
       )
     }
 
-    if (shouldEnsureLayout) {
-      applyLayoutRecursive(node, 0F, 0F)
-    }
+    applyLayoutRecursive(node, 0F, 0F)
+
   }
 
   private fun setSizeFromMeasureSpec(widthMeasureSpec: Int, heightMeasureSpec: Int) {
@@ -353,7 +294,12 @@ class View @JvmOverloads constructor(
     }
 
     val layout = if (parent !is View) {
-      node.computeAndLayout(specWidth.toFloat(), specHeight.toFloat())
+      if (node.style.size.height is Dimension.Auto || node.style.size.width is Dimension.Auto) {
+        node.computeMaxContent()
+      } else {
+        node.computeAndLayout(specWidth.toFloat(), specHeight.toFloat())
+      }
+      node.layout()
     } else {
       node.layout()
     }

--- a/packages/nativescript-masonkit/src-native/mason-native/mason-core/src/lib.rs
+++ b/packages/nativescript-masonkit/src-native/mason-native/mason-core/src/lib.rs
@@ -306,9 +306,19 @@ impl Mason {
     }
 
     pub fn compute_wh(&mut self, node: Node, width: f32, height: f32) {
+        let min_size = Size::<AvailableSpace>::min_content();
+        let max_size = Size::<AvailableSpace>::max_content();
         let size = taffy::geometry::Size {
-            width: AvailableSpace::Definite(width),
-            height: AvailableSpace::Definite(height),
+            width: match width {
+                x if x == -1.0 => min_size.size.width,
+                x if x == -2.0 => max_size.size.width,
+                _ => AvailableSpace::Definite(width)
+            },
+            height: match height {
+                x if x == -1.0 => min_size.size.height,
+                x if x == -2.0 => max_size.size.height,
+                _ => AvailableSpace::Definite(height)
+            }
         };
         let _ = self.taffy.compute_layout(node.node, size);
     }


### PR DESCRIPTION
This change properly handles view sizing for root nodes when set to auto or percentage width/height instead of fixed values, for example `width: 50%` inside a `GridLayout` or views without a parent node with width/height set to auto.