### PR TITLE
feat: implement radial gradient positioning and reverse layer drawing…

### DIFF
--- a/packages/nativescript-masonkit/src-native/mason-android/masonkit/src/main/java/org/nativescript/mason/masonkit/Background.kt
+++ b/packages/nativescript-masonkit/src-native/mason-android/masonkit/src/main/java/org/nativescript/mason/masonkit/Background.kt
@@ -255,13 +255,16 @@ fun drawGradient(layer: BackgroundLayer, canvas: Canvas, width: Int, height: Int
       }
 
       "radial" -> {
+        val (cx, cy) = resolveRadialGradientCenter(gradient.direction, width.toFloat(), height.toFloat())
+        // Radius must reach the farthest corner from the resolved centre.
+        val radius = maxOf(
+          Math.hypot((cx).toDouble(), (cy).toDouble()),
+          Math.hypot((width - cx).toDouble(), (cy).toDouble()),
+          Math.hypot((cx).toDouble(), (height - cy).toDouble()),
+          Math.hypot((width - cx).toDouble(), (height - cy).toDouble())
+        ).toFloat().coerceAtLeast(1f)
         RadialGradient(
-          width / 2f,
-          height / 2f,
-          maxOf(width, height) / 2f,
-          colorsArray,
-          positionsArray,
-          Shader.TileMode.CLAMP
+          cx, cy, radius, colorsArray, positionsArray, Shader.TileMode.CLAMP
         )
       }
 
@@ -344,6 +347,87 @@ private fun parseCssAngleToRadians(value: String): Double? {
 
     v.endsWith("rad") -> v.removeSuffix("rad").toDoubleOrNull()
     else -> null
+  }
+}
+
+/**
+ * Resolve the centre point of a radial-gradient from the CSS direction string.
+ *
+ * Accepted formats include:
+ *   "circle at top left", "ellipse at 30% 70%", "at center", "circle", etc.
+ *
+ * When no position is given the default is the element centre (50% 50%).
+ */
+private fun resolveRadialGradientCenter(
+  direction: String?,
+  width: Float,
+  height: Float
+): Pair<Float, Float> {
+  val defaultCenter = Pair(width / 2f, height / 2f)
+  val dir = direction?.trim()?.lowercase() ?: return defaultCenter
+
+  // Extract the position portion after "at "
+  val atIndex = dir.indexOf(" at ")
+  val positionStr = if (atIndex >= 0) dir.substring(atIndex + 4).trim() else return defaultCenter
+  if (positionStr.isEmpty()) return defaultCenter
+
+  return resolvePositionKeywords(positionStr, width, height)
+}
+
+/**
+ * Convert a CSS background-position value (keyword or percentage based) to
+ * absolute pixel coordinates.
+ *
+ * Supports: named keywords (top, bottom, left, right, center) and percentage
+ * values (e.g. "30%" or "30% 70%").
+ */
+private fun resolvePositionKeywords(
+  position: String,
+  width: Float,
+  height: Float
+): Pair<Float, Float> {
+  val parts = position.split(Regex("\\s+"))
+
+  fun resolveToken(token: String, horizontal: Boolean): Float {
+    return when (token) {
+      "left" -> 0f
+      "right" -> width
+      "top" -> 0f
+      "bottom" -> height
+      "center" -> if (horizontal) width / 2f else height / 2f
+      else -> {
+        if (token.endsWith("%")) {
+          val pct = token.removeSuffix("%").toFloatOrNull() ?: 50f
+          if (horizontal) pct / 100f * width else pct / 100f * height
+        } else {
+          val num = token.removeSuffix("px").toFloatOrNull()
+          if (num != null) num * Mason.shared.scale
+          else if (horizontal) width / 2f else height / 2f
+        }
+      }
+    }
+  }
+
+  return when (parts.size) {
+    1 -> {
+      val x = resolveToken(parts[0], horizontal = true)
+      val y = when (parts[0]) {
+        "top" -> 0f
+        "bottom" -> height
+        // Single keyword like "center", "left", "right" → y defaults to 50%
+        else -> height / 2f
+      }
+      // For "top"/"bottom" used alone, x defaults to center
+      val finalX = when (parts[0]) {
+        "top", "bottom" -> width / 2f
+        else -> x
+      }
+      Pair(finalX, y)
+    }
+    else -> Pair(
+      resolveToken(parts[0], horizontal = true),
+      resolveToken(parts[1], horizontal = false)
+    )
   }
 }
 

--- a/packages/nativescript-masonkit/src-native/mason-android/masonkit/src/main/java/org/nativescript/mason/masonkit/ViewUtils.kt
+++ b/packages/nativescript-masonkit/src-native/mason-android/masonkit/src/main/java/org/nativescript/mason/masonkit/ViewUtils.kt
@@ -116,7 +116,8 @@ class ViewUtils {
                 canvas.drawRect(0f, 0f, width, height, background.bgPaint)
               }
 
-              background.layers.forEach { layer ->
+              // Reverse so the first layer in the list is drawn on top.
+              background.layers.asReversed().forEach { layer ->
                 canvas.withSave {
                   // pass measured bounds so clip uses the real size instead of the
                   // potentially-zero computedWidth/Height stored on the node

--- a/packages/nativescript-masonkit/src-native/mason-ios/Mason/Mason/Background.swift
+++ b/packages/nativescript-masonkit/src-native/mason-ios/Mason/Mason/Background.swift
@@ -23,7 +23,7 @@ extension Background {
       context.fill(rect)
     }
     
-    for bgLayer in layers {
+    for bgLayer in layers.reversed() {
       drawLayer(bgLayer, on: nil, on: layer, in: context, rect: rect)
     }
 
@@ -36,7 +36,7 @@ extension Background {
       context.fill(rect)
     }
 
-    for layer in layers {
+    for layer in layers.reversed() {
       drawLayer(layer, on: view, in: context, rect: rect)
     }
   }
@@ -106,8 +106,14 @@ extension Background {
       let (start, end) = linearGradientPoints(direction: gradient.direction, width: width, height: height)
       context.drawLinearGradient(shader, start: start, end: end, options: [])
     case "radial":
-      let center = CGPoint(x: width/2, y: height/2)
-      let radius = max(width, height) / 2
+      let center = resolveRadialGradientCenter(direction: gradient.direction, width: width, height: height)
+      // Radius must reach the farthest corner from the resolved centre.
+      let radius = max([
+        hypot(center.x, center.y),
+        hypot(width - center.x, center.y),
+        hypot(center.x, height - center.y),
+        hypot(width - center.x, height - center.y)
+      ].max() ?? max(width, height) / 2, 1)
       context.drawRadialGradient(shader, startCenter: center, startRadius: 0, endCenter: center, endRadius: radius, options: [])
     default:
       break
@@ -244,8 +250,14 @@ func drawGradient(layer: BackgroundLayer, context: CGContext, width: CGFloat, he
     context.drawLinearGradient(shader, start: start, end: end, options: [])
     
   case "radial":
-    let center = CGPoint(x: width/2, y: height/2)
-    let radius = max(width, height) / 2
+    let center = resolveRadialGradientCenter(direction: gradient.direction, width: width, height: height)
+    // Radius must reach the farthest corner from the resolved centre.
+    let radius = max([
+      hypot(center.x, center.y),
+      hypot(width - center.x, center.y),
+      hypot(center.x, height - center.y),
+      hypot(width - center.x, height - center.y)
+    ].max() ?? max(width, height) / 2, 1)
     context.drawRadialGradient(shader,
                                startCenter: center,
                                startRadius: 0,
@@ -288,6 +300,62 @@ func linearGradientPoints(direction: String?, width: CGFloat, height: CGFloat)
     // fallback
     return (CGPoint(x: 0, y: 0), CGPoint(x: 0, y: height))
   }
+}
+
+/// Resolve the centre point of a radial-gradient from the CSS direction string.
+///
+/// Accepted formats: "circle at top left", "ellipse at 30% 70%",
+/// "at center", "circle", etc.  Defaults to the element centre (50% 50%).
+func resolveRadialGradientCenter(direction: String?, width: CGFloat, height: CGFloat) -> CGPoint {
+  let defaultCenter = CGPoint(x: width / 2, y: height / 2)
+  guard let dir = direction?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() else {
+    return defaultCenter
+  }
+
+  // Extract the portion after "at "
+  guard let atRange = dir.range(of: " at ") else { return defaultCenter }
+  let positionStr = String(dir[atRange.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
+  if positionStr.isEmpty { return defaultCenter }
+
+  return resolvePositionKeywords(positionStr, width: width, height: height)
+}
+
+/// Convert a CSS background-position value (keyword or percentage based) to
+/// absolute pixel coordinates.
+private func resolvePositionKeywords(_ position: String, width: CGFloat, height: CGFloat) -> CGPoint {
+  let parts = position.split(separator: " ").map { String($0) }
+
+  func resolveToken(_ token: String, horizontal: Bool) -> CGFloat {
+    switch token {
+    case "left":   return 0
+    case "right":  return width
+    case "top":    return 0
+    case "bottom": return height
+    case "center": return horizontal ? width / 2 : height / 2
+    default:
+      if token.hasSuffix("%"), let pct = Double(token.dropLast()) {
+        return CGFloat(pct / 100) * (horizontal ? width : height)
+      }
+      let cleaned = token.hasSuffix("px") ? String(token.dropLast(2)) : token
+      if let px = Double(cleaned) { return CGFloat(px) }
+      return horizontal ? width / 2 : height / 2
+    }
+  }
+
+  if parts.count == 1 {
+    switch parts[0] {
+    case "top":    return CGPoint(x: width / 2, y: 0)
+    case "bottom": return CGPoint(x: width / 2, y: height)
+    default:
+      let x = resolveToken(parts[0], horizontal: true)
+      return CGPoint(x: x, y: height / 2)
+    }
+  }
+
+  return CGPoint(
+    x: resolveToken(parts[0], horizontal: true),
+    y: resolveToken(parts[1], horizontal: false)
+  )
 }
 
 // MARK: - Bitmap Drawing


### PR DESCRIPTION
CSS spec says the first listed background is the topmost layer (painted last). We were iterating forward, so layers rendered bottom to top instead.

radial-gradient(circle at top left, ...) was always rendering at center.