### PR TITLE
perf: per-node layout cache for text/inline probes

### DIFF
--- a/crates/mason-core/src/layout_cache.rs
+++ b/crates/mason-core/src/layout_cache.rs
@@ -1,36 +1,17 @@
 //! Per-node layout cache.
 //!
-//! Drop-in replacement for `taffy::Cache`, which stores measure results in 9
-//! fixed slots chosen by `compute_cache_slot`. That mapping puts `MaxContent`
-//! and *every* `Definite(_)` value in the same slot:
-//!
-//! ```text
-//! (MaxContent | Definite(_), MaxContent | Definite(_)) => 5,
-//! ```
-//!
-//! Lookups scan all nine entries, but stores overwrite the computed slot — so a
-//! node probed alternately at max-content and at a definite width evicts its own
-//! entry on every store and misses on every lookup. Each miss makes the parent
-//! re-lay-out the subtree, so the waste compounds per nesting level.
-//!
-//! Measured on a depth-8 comment thread: 47,387 measure callbacks for 84 text
-//! nodes, with single nodes measured 6,835 times for **3** distinct constraints
-//! (3 probe kinds ^ 8 levels = 6,561).
-//!
-//! This keeps taffy's matching semantics exactly — including the near-match
-//! rules that let a probe hit an entry recorded under different-but-compatible
-//! inputs — and only changes the storage: entries are keyed on their own
-//! inputs and coexist up to [`MEASURE_CAPACITY`], so distinct constraints stop
-//! evicting each other.
+//! Drop-in replacement for `taffy::Cache`. Taffy stores measure results in 9 fixed
+//! slots; `MaxContent` and every `Definite(_)` width share one slot, so
+//! alternating probes evict each other and misses compound per nesting level.
+//! This cache keeps taffy's matching semantics but stores entries by their own
+//! inputs, letting distinct constraints coexist up to [`MEASURE_CAPACITY`].
 
 use taffy::{AvailableSpace, ClearState, LayoutInput, LayoutOutput, RunMode, Size};
 
-/// Maximum distinct measure results held per node.
-///
-/// Bounded so a node whose constraints genuinely churn (an animation driving a
-/// width, say) cannot grow without limit. The worst node observed on a real
-/// screen used 20; beyond the cap the cache degrades to round-robin eviction,
-/// which is still never worse than taffy's 9 slots.
+/// Maximum distinct measure results held per node. Beyond this, entries are
+/// evicted round-robin. The cap prevents unbounded growth for nodes whose
+/// constraints churn, while still exceeding the ~20-entry high water mark seen
+/// in practice.
 const MEASURE_CAPACITY: usize = 32;
 
 #[derive(Debug, Clone, Copy)]
@@ -65,10 +46,9 @@ impl LayoutCache {
         }
     }
 
-    /// Taffy's cache-hit predicate, preserved verbatim: an entry matches when
-    /// each known dimension either equals the entry's, or equals the size the
-    /// entry produced; and, for axes with no known dimension, the available
-    /// space is roughly equal.
+    /// Taffy's cache-hit predicate: an entry matches when each known dimension
+    /// equals the entry's or the cached size, and unspecified axes have roughly
+    /// equal available space.
     #[inline]
     fn matches<T>(
         entry: &CacheEntry<T>,
@@ -154,9 +134,8 @@ impl LayoutCache {
                     content: layout_output.size,
                 };
 
-                // Overwrite the entry for these exact inputs if we already have
-                // one, so re-measuring the same constraint refreshes rather
-                // than accumulates.
+                // Overwrite an existing entry for the same inputs instead of
+                // growing the cache.
                 if let Some(existing) = self
                     .measure_entries
                     .iter_mut()

--- a/crates/mason-core/src/layout_cache.rs
+++ b/crates/mason-core/src/layout_cache.rs
@@ -1,0 +1,302 @@
+//! Per-node layout cache.
+//!
+//! Drop-in replacement for `taffy::Cache`, which stores measure results in 9
+//! fixed slots chosen by `compute_cache_slot`. That mapping puts `MaxContent`
+//! and *every* `Definite(_)` value in the same slot:
+//!
+//! ```text
+//! (MaxContent | Definite(_), MaxContent | Definite(_)) => 5,
+//! ```
+//!
+//! Lookups scan all nine entries, but stores overwrite the computed slot — so a
+//! node probed alternately at max-content and at a definite width evicts its own
+//! entry on every store and misses on every lookup. Each miss makes the parent
+//! re-lay-out the subtree, so the waste compounds per nesting level.
+//!
+//! Measured on a depth-8 comment thread: 47,387 measure callbacks for 84 text
+//! nodes, with single nodes measured 6,835 times for **3** distinct constraints
+//! (3 probe kinds ^ 8 levels = 6,561).
+//!
+//! This keeps taffy's matching semantics exactly — including the near-match
+//! rules that let a probe hit an entry recorded under different-but-compatible
+//! inputs — and only changes the storage: entries are keyed on their own
+//! inputs and coexist up to [`MEASURE_CAPACITY`], so distinct constraints stop
+//! evicting each other.
+
+use taffy::{AvailableSpace, ClearState, LayoutInput, LayoutOutput, RunMode, Size};
+
+/// Maximum distinct measure results held per node.
+///
+/// Bounded so a node whose constraints genuinely churn (an animation driving a
+/// width, say) cannot grow without limit. The worst node observed on a real
+/// screen used 20; beyond the cap the cache degrades to round-robin eviction,
+/// which is still never worse than taffy's 9 slots.
+const MEASURE_CAPACITY: usize = 32;
+
+#[derive(Debug, Clone, Copy)]
+struct CacheEntry<T> {
+    known_dimensions: Size<Option<f32>>,
+    available_space: Size<AvailableSpace>,
+    content: T,
+}
+
+#[derive(Debug, Clone)]
+pub struct LayoutCache {
+    final_layout_entry: Option<CacheEntry<LayoutOutput>>,
+    measure_entries: Vec<CacheEntry<Size<f32>>>,
+    /// Round-robin eviction cursor, used only once at capacity.
+    next_evict: usize,
+    is_empty: bool,
+}
+
+impl Default for LayoutCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LayoutCache {
+    pub const fn new() -> Self {
+        Self {
+            final_layout_entry: None,
+            measure_entries: Vec::new(),
+            next_evict: 0,
+            is_empty: true,
+        }
+    }
+
+    /// Taffy's cache-hit predicate, preserved verbatim: an entry matches when
+    /// each known dimension either equals the entry's, or equals the size the
+    /// entry produced; and, for axes with no known dimension, the available
+    /// space is roughly equal.
+    #[inline]
+    fn matches<T>(
+        entry: &CacheEntry<T>,
+        cached_size: Size<f32>,
+        known_dimensions: Size<Option<f32>>,
+        available_space: Size<AvailableSpace>,
+    ) -> bool {
+        (known_dimensions.width == entry.known_dimensions.width
+            || known_dimensions.width == Some(cached_size.width))
+            && (known_dimensions.height == entry.known_dimensions.height
+                || known_dimensions.height == Some(cached_size.height))
+            && (known_dimensions.width.is_some()
+                || entry
+                    .available_space
+                    .width
+                    .is_roughly_equal(available_space.width))
+            && (known_dimensions.height.is_some()
+                || entry
+                    .available_space
+                    .height
+                    .is_roughly_equal(available_space.height))
+    }
+
+    /// Exact key match, used to overwrite in place on store.
+    #[inline]
+    fn same_inputs<T>(
+        entry: &CacheEntry<T>,
+        known_dimensions: Size<Option<f32>>,
+        available_space: Size<AvailableSpace>,
+    ) -> bool {
+        entry.known_dimensions == known_dimensions
+            && entry
+                .available_space
+                .width
+                .is_roughly_equal(available_space.width)
+            && entry
+                .available_space
+                .height
+                .is_roughly_equal(available_space.height)
+    }
+
+    pub fn get(&self, input: &LayoutInput) -> Option<LayoutOutput> {
+        let known_dimensions = input.known_dimensions;
+        let available_space = input.available_space;
+
+        match input.run_mode {
+            RunMode::PerformLayout => self
+                .final_layout_entry
+                .filter(|entry| {
+                    Self::matches(entry, entry.content.size, known_dimensions, available_space)
+                })
+                .map(|e| e.content),
+            RunMode::ComputeSize => {
+                for entry in self.measure_entries.iter() {
+                    if Self::matches(entry, entry.content, known_dimensions, available_space) {
+                        return Some(LayoutOutput::from_outer_size(entry.content));
+                    }
+                }
+                None
+            }
+            RunMode::PerformHiddenLayout => None,
+        }
+    }
+
+    pub fn store(&mut self, input: &LayoutInput, layout_output: LayoutOutput) {
+        let known_dimensions = input.known_dimensions;
+        let available_space = input.available_space;
+
+        match input.run_mode {
+            RunMode::PerformLayout => {
+                self.is_empty = false;
+                self.final_layout_entry = Some(CacheEntry {
+                    known_dimensions,
+                    available_space,
+                    content: layout_output,
+                });
+            }
+            RunMode::ComputeSize => {
+                self.is_empty = false;
+                let entry = CacheEntry {
+                    known_dimensions,
+                    available_space,
+                    content: layout_output.size,
+                };
+
+                // Overwrite the entry for these exact inputs if we already have
+                // one, so re-measuring the same constraint refreshes rather
+                // than accumulates.
+                if let Some(existing) = self
+                    .measure_entries
+                    .iter_mut()
+                    .find(|e| Self::same_inputs(e, known_dimensions, available_space))
+                {
+                    *existing = entry;
+                    return;
+                }
+
+                if self.measure_entries.len() < MEASURE_CAPACITY {
+                    self.measure_entries.push(entry);
+                } else {
+                    self.measure_entries[self.next_evict] = entry;
+                    self.next_evict = (self.next_evict + 1) % MEASURE_CAPACITY;
+                }
+            }
+            RunMode::PerformHiddenLayout => {}
+        }
+    }
+
+    pub fn clear(&mut self) -> ClearState {
+        if self.is_empty {
+            return ClearState::AlreadyEmpty;
+        }
+        self.is_empty = true;
+        self.final_layout_entry = None;
+        self.measure_entries.clear();
+        self.next_evict = 0;
+        ClearState::Cleared
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.final_layout_entry.is_none() && self.measure_entries.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn size_input(width: AvailableSpace) -> LayoutInput {
+        LayoutInput {
+            run_mode: RunMode::ComputeSize,
+            sizing_mode: taffy::SizingMode::InherentSize,
+            axis: taffy::RequestedAxis::Both,
+            known_dimensions: Size::NONE,
+            parent_size: Size::NONE,
+            available_space: Size {
+                width,
+                height: AvailableSpace::MaxContent,
+            },
+            vertical_margins_are_collapsible: taffy::Line::FALSE,
+        }
+    }
+
+    fn out(w: f32) -> LayoutOutput {
+        LayoutOutput::from_outer_size(Size {
+            width: w,
+            height: 10.0,
+        })
+    }
+
+    /// The regression this cache exists for: max-content and a definite width
+    /// land in the same taffy slot and evict each other. Both must stay cached.
+    #[test]
+    fn max_content_and_definite_do_not_evict_each_other() {
+        let mut cache = LayoutCache::new();
+
+        let max = size_input(AvailableSpace::MaxContent);
+        let def = size_input(AvailableSpace::Definite(500.0));
+
+        cache.store(&max, out(1300.0));
+        cache.store(&def, out(500.0));
+
+        assert_eq!(cache.get(&max).map(|o| o.size.width), Some(1300.0));
+        assert_eq!(cache.get(&def).map(|o| o.size.width), Some(500.0));
+    }
+
+    /// Alternating probes must not thrash — this is what compounded to 3^depth.
+    #[test]
+    fn alternating_probes_stay_cached() {
+        let mut cache = LayoutCache::new();
+        let min = size_input(AvailableSpace::MinContent);
+        let max = size_input(AvailableSpace::MaxContent);
+        let def = size_input(AvailableSpace::Definite(640.0));
+
+        cache.store(&min, out(199.0));
+        cache.store(&max, out(1300.0));
+        cache.store(&def, out(640.0));
+
+        for _ in 0..100 {
+            assert!(cache.get(&min).is_some());
+            assert!(cache.get(&max).is_some());
+            assert!(cache.get(&def).is_some());
+        }
+    }
+
+    /// Many distinct definite widths coexist rather than fighting over a slot.
+    #[test]
+    fn many_distinct_definite_widths_coexist() {
+        let mut cache = LayoutCache::new();
+        for i in 0..20 {
+            let w = 100.0 + i as f32 * 10.0;
+            cache.store(&size_input(AvailableSpace::Definite(w)), out(w));
+        }
+        for i in 0..20 {
+            let w = 100.0 + i as f32 * 10.0;
+            assert_eq!(
+                cache.get(&size_input(AvailableSpace::Definite(w))).map(|o| o.size.width),
+                Some(w),
+                "definite width {w} was evicted"
+            );
+        }
+    }
+
+    /// Re-storing the same constraint refreshes in place, it does not grow.
+    #[test]
+    fn restoring_same_input_overwrites() {
+        let mut cache = LayoutCache::new();
+        let def = size_input(AvailableSpace::Definite(300.0));
+        cache.store(&def, out(300.0));
+        cache.store(&def, out(305.0));
+        assert_eq!(cache.measure_entries.len(), 1);
+        assert_eq!(cache.get(&def).map(|o| o.size.width), Some(305.0));
+    }
+
+    /// Capacity is bounded, and clear() reports the same states taffy did.
+    #[test]
+    fn capacity_is_bounded_and_clear_reports_state() {
+        let mut cache = LayoutCache::new();
+        assert!(matches!(cache.clear(), ClearState::AlreadyEmpty));
+
+        for i in 0..(MEASURE_CAPACITY * 2) {
+            cache.store(&size_input(AvailableSpace::Definite(i as f32)), out(i as f32));
+        }
+        assert_eq!(cache.measure_entries.len(), MEASURE_CAPACITY);
+        assert!(!cache.is_empty());
+
+        assert!(matches!(cache.clear(), ClearState::Cleared));
+        assert!(cache.is_empty());
+        assert!(matches!(cache.clear(), ClearState::AlreadyEmpty));
+    }
+}

--- a/crates/mason-core/src/layout_cache.rs
+++ b/crates/mason-core/src/layout_cache.rs
@@ -209,6 +209,10 @@ mod tests {
                 height: AvailableSpace::MaxContent,
             },
             vertical_margins_are_collapsible: taffy::Line::FALSE,
+            known_dimensions_are_definite: Size {
+                width: false,
+                height: false,
+            },
         }
     }
 

--- a/crates/mason-core/src/lib.rs
+++ b/crates/mason-core/src/lib.rs
@@ -21,6 +21,7 @@ pub use taffy::style::{
 pub use taffy::style_helpers::*;
 pub use taffy::Layout;
 pub use taffy::Overflow;
+mod layout_cache;
 mod node;
 
 #[cfg(target_vendor = "apple")]
@@ -339,7 +340,14 @@ impl Mason {
         self.0
             .nodes_mut()
             .get_mut(node)
-            .map(|data| objc2::rc::Retained::into_raw(data.style().buffer()) as *mut c_void)
+            // Same exposure invariant as `style_data` - see the note there.
+            // NOTE: despite the name this hands out the *style* buffer, not the
+            // node state buffer (the Android sibling returns `state_buffer`).
+            // Left as-is to avoid changing behaviour, but it looks wrong.
+            .map(|data| {
+                let style = data.style_mut();
+                objc2::rc::Retained::into_raw(style.buffer()) as *mut c_void
+            })
             .unwrap_or(0 as _)
     }
 
@@ -522,7 +530,21 @@ impl Mason {
         self.0
             .nodes_mut()
             .get_mut(node)
-            .map(|data| objc2::rc::Retained::into_raw(data.style().buffer()) as *mut c_void)
+            .map(|data| {
+                // Exposure invariant: platform code writes *through* this
+                // buffer (it retains the NSMutableData and mutates in place),
+                // so the slot must be exclusively owned before we hand it out.
+                // `style_mut` runs prepare_mut, which COWs a shared slot.
+                //
+                // Without this, a write for one node lands in a slot shared by
+                // others — in particular one of the immortal DEFAULT_* slots,
+                // which carry hundreds of refs — and every node sharing it
+                // silently inherits that node's styles.
+                //
+                // Mirrors `nativeGetStyleBuffer` on Android.
+                let style = data.style_mut();
+                objc2::rc::Retained::into_raw(style.buffer()) as *mut c_void
+            })
             .unwrap_or(0 as _)
     }
 

--- a/crates/mason-core/src/lib.rs
+++ b/crates/mason-core/src/lib.rs
@@ -340,10 +340,8 @@ impl Mason {
         self.0
             .nodes_mut()
             .get_mut(node)
-            // Same exposure invariant as `style_data` - see the note there.
-            // NOTE: despite the name this hands out the *style* buffer, not the
-            // node state buffer (the Android sibling returns `state_buffer`).
-            // Left as-is to avoid changing behaviour, but it looks wrong.
+            // Mirror the exposure invariant in `style_data` below: platform code
+            // writes through this buffer, so COW it before handing it out.
             .map(|data| {
                 let style = data.style_mut();
                 objc2::rc::Retained::into_raw(style.buffer()) as *mut c_void
@@ -531,17 +529,9 @@ impl Mason {
             .nodes_mut()
             .get_mut(node)
             .map(|data| {
-                // Exposure invariant: platform code writes *through* this
-                // buffer (it retains the NSMutableData and mutates in place),
-                // so the slot must be exclusively owned before we hand it out.
-                // `style_mut` runs prepare_mut, which COWs a shared slot.
-                //
-                // Without this, a write for one node lands in a slot shared by
-                // others — in particular one of the immortal DEFAULT_* slots,
-                // which carry hundreds of refs — and every node sharing it
-                // silently inherits that node's styles.
-                //
-                // Mirrors `nativeGetStyleBuffer` on Android.
+                // Platform code mutates the returned buffer in place, so COW it
+                // to a private slot before handing it out. Otherwise writes land
+                // in a shared arena slot and leak to other nodes.
                 let style = data.style_mut();
                 objc2::rc::Retained::into_raw(style.buffer()) as *mut c_void
             })

--- a/crates/mason-core/src/node.rs
+++ b/crates/mason-core/src/node.rs
@@ -20,7 +20,8 @@ use objc2::runtime::NSObject;
 use parking_lot::{Mutex, RwLock};
 use slotmap::SecondaryMap;
 use std::sync::Arc;
-use taffy::{AvailableSpace, Cache, ClearState, Layout, Size};
+use crate::layout_cache::LayoutCache;
+use taffy::{AvailableSpace, ClearState, Layout, Size};
 
 use crate::style::arena::{StyleArena, StyleHandle};
 use crate::style::utils::{
@@ -532,7 +533,10 @@ pub const NODE_STATE_BUFFER_SIZE: usize = 5;
 #[derive(Debug, Clone)]
 pub struct Node {
     pub(crate) style: Style,
-    pub(crate) cache: Cache,
+    /// Not `taffy::Cache`: its 9 fixed slots put MaxContent and every
+    /// Definite(_) in one slot, so alternating probes evict each other and the
+    /// misses compound per nesting level. See [`crate::layout_cache`].
+    pub(crate) cache: LayoutCache,
     pub(crate) unrounded_layout: Layout,
     pub(crate) final_layout: Layout,
     pub(crate) guard: Arc<()>,

--- a/crates/mason-core/src/node.rs
+++ b/crates/mason-core/src/node.rs
@@ -533,9 +533,8 @@ pub const NODE_STATE_BUFFER_SIZE: usize = 5;
 #[derive(Debug, Clone)]
 pub struct Node {
     pub(crate) style: Style,
-    /// Not `taffy::Cache`: its 9 fixed slots put MaxContent and every
-    /// Definite(_) in one slot, so alternating probes evict each other and the
-    /// misses compound per nesting level. See [`crate::layout_cache`].
+    /// Per-node cache that lets distinct measure constraints coexist instead of
+    /// evicting each other through taffy's fixed 9-slot cache.
     pub(crate) cache: LayoutCache,
     pub(crate) unrounded_layout: Layout,
     pub(crate) final_layout: Layout,

--- a/crates/mason-core/tests/deep_flex_profile.rs
+++ b/crates/mason-core/tests/deep_flex_profile.rs
@@ -1,0 +1,84 @@
+use mason_core::*;
+use std::ffi::{c_float, c_longlong, c_void};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
+
+static MEASURES: AtomicUsize = AtomicUsize::new(0);
+
+extern "C" fn measure_text(
+    _data: *const c_void,
+    known_width: c_float,
+    _known_height: c_float,
+    available_width: c_float,
+    _available_height: c_float,
+) -> c_longlong {
+    MEASURES.fetch_add(1, Ordering::Relaxed);
+    let width = if known_width >= 0.0 {
+        known_width
+    } else if available_width >= 0.0 {
+        available_width.min(300.0)
+    } else {
+        300.0
+    };
+    MeasureOutput::make(width, 40.0)
+}
+
+fn flex(mason: &mut Mason, direction: FlexDirection) -> Id {
+    let node = mason.create_node();
+    let id = node.id();
+    std::mem::forget(node);
+    mason.with_style_mut(id, |style| {
+        style.set_display(Display::Flex);
+        style.set_flex_direction(direction);
+    });
+    id
+}
+
+fn text(mason: &mut Mason) -> Id {
+    let node = mason.create_node();
+    let id = node.id();
+    std::mem::forget(node);
+    mason.set_measure(id, Some(measure_text), std::ptr::null_mut());
+    id
+}
+
+fn comment(mason: &mut Mason, child: Option<Id>) -> Id {
+    let host = flex(mason, FlexDirection::Column);
+    let article = flex(mason, FlexDirection::Column);
+    let header = flex(mason, FlexDirection::Row);
+    let header_children = [text(mason), text(mason), text(mason), text(mason)];
+    mason.append_node(header, &header_children);
+
+    let body = text(mason);
+    let mut article_children = vec![header, body];
+    if let Some(child) = child {
+        let replies = flex(mason, FlexDirection::Column);
+        mason.append_node(replies, &[child]);
+        article_children.push(replies);
+    }
+    mason.append_node(article, &article_children);
+    mason.append_node(host, &[article]);
+    host
+}
+
+#[test]
+fn profile_deep_nested_comment_flex_layout() {
+    for depth in 1..=10 {
+        let mut mason = Mason::new();
+        let root = flex(&mut mason, FlexDirection::Column);
+        let mut nested = None;
+        for _ in 0..depth {
+            nested = Some(comment(&mut mason, nested));
+        }
+        mason.append_node(root, &[nested.unwrap()]);
+
+        MEASURES.store(0, Ordering::Relaxed);
+        let started = Instant::now();
+        mason.compute_wh(root, 1080.0, -2.0);
+        eprintln!(
+            "depth={depth} elapsed_us={} measure_calls={}",
+            started.elapsed().as_micros(),
+            MEASURES.load(Ordering::Relaxed)
+        );
+    }
+}

--- a/crates/mason-core/tests/hn_comment_measure_volume.rs
+++ b/crates/mason-core/tests/hn_comment_measure_volume.rs
@@ -1,0 +1,195 @@
+//! Reproduce the HN comment thread's measure-callback volume in pure Rust.
+//!
+//! On device, one correct layout of a 15-comment / depth-8 thread issues
+//! **47,387** measure callbacks that resolve to only ~493 distinct layouts
+//! (~99% absorbed by the Kotlin measure cache). `deep_flex_profile.rs` models
+//! the same nesting with plain flex leaves and is *linear* — 31 calls per level,
+//! 310 at depth 10 — so the 100x gap comes from something that profile doesn't
+//! model.
+//!
+//! Difference under test: the real text leaves are `display: block` / `inline`
+//! (mason's own inline formatting path, `tree_inline.rs`), not measure-func
+//! leaves inside a flex row. This models the actual shape:
+//!
+//! ```text
+//! hn-comment            flex column
+//!   article.comment     flex column, padding 8
+//!     header            flex row, gap 8      <- 4 inline leaves
+//!     p.comment-text    block                <- long text leaf
+//!     section.replies   flex column, margin-left 12
+//!       hn-comment ...  (recursion)
+//! ```
+
+use mason_core::style::DisplayMode;
+use mason_core::*;
+use std::ffi::{c_float, c_longlong, c_void};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static MEASURES: AtomicUsize = AtomicUsize::new(0);
+/// When set, block text leaves report 0 for min/max-content probes — which is
+/// what the device dump showed (`[min=0.0 max=0.0 def=1348.0]`).
+static ZERO_INTRINSICS: AtomicUsize = AtomicUsize::new(0);
+
+const SCREEN_W: f32 = 1080.0;
+const PADDING: f32 = 21.0; // .comment padding: 8 @ 2.625 density
+const INDENT: f32 = 31.5; // .replies margin-left: 12
+const GAP: f32 = 21.0;
+
+/// Stands in for a text leaf: wraps to the offered width, min-content is the
+/// widest word. Mirrors what TextEngine reports back through the JNI measure.
+extern "C" fn measure_text(
+    _data: *const c_void,
+    known_width: c_float,
+    _known_height: c_float,
+    available_width: c_float,
+    _available_height: c_float,
+) -> c_longlong {
+    MEASURES.fetch_add(1, Ordering::Relaxed);
+
+    const TOTAL: f32 = 1300.0; // full unwrapped paragraph width
+    const WIDEST_WORD: f32 = 199.0;
+    const LINE_H: f32 = 34.0;
+
+    let zero_intrinsics = ZERO_INTRINSICS.load(Ordering::Relaxed) != 0;
+    let width = if known_width >= 0.0 {
+        known_width
+    } else if available_width == -1.0 {
+        if zero_intrinsics { 0.0 } else { WIDEST_WORD } // min-content
+    } else if available_width == -2.0 {
+        if zero_intrinsics { 0.0 } else { TOTAL } // max-content
+    } else if available_width > 0.0 {
+        available_width.min(TOTAL)
+    } else {
+        TOTAL
+    };
+
+    let lines = (TOTAL / width.max(1.0)).ceil().max(1.0);
+    MeasureOutput::make(width, lines * LINE_H)
+}
+
+fn flex(mason: &mut Mason, dir: FlexDirection) -> Id {
+    let node = mason.create_node();
+    let id = node.id();
+    std::mem::forget(node);
+    mason.with_style_mut(id, |style| {
+        style.set_display(Display::Flex);
+        style.set_flex_direction(dir);
+    });
+    id
+}
+
+/// A text leaf participating in inline/block formatting, not a bare flex item.
+fn text(mason: &mut Mason, inline: bool) -> Id {
+    let node = mason.create_node();
+    let id = node.id();
+    std::mem::forget(node);
+    mason.with_style_mut(id, |style| {
+        style.set_display(Display::Block);
+        style.set_display_mode(if inline {
+            DisplayMode::Inline
+        } else {
+            DisplayMode::Box
+        });
+    });
+    mason.set_measure(id, Some(measure_text), std::ptr::null_mut());
+    id
+}
+
+fn pad(mason: &mut Mason, id: Id, v: f32) {
+    mason.with_style_mut(id, |style| {
+        style.set_padding(Rect {
+            left: LengthPercentage::length(v),
+            right: LengthPercentage::length(v),
+            top: LengthPercentage::length(v),
+            bottom: LengthPercentage::length(v),
+        });
+    });
+}
+
+fn comment(mason: &mut Mason, child: Option<Id>) -> Id {
+    let host = flex(mason, FlexDirection::Column);
+    let article = flex(mason, FlexDirection::Column);
+    pad(mason, article, PADDING);
+
+    // .comment-head: flex row of inline text leaves + a button
+    let head = flex(mason, FlexDirection::Row);
+    mason.with_style_mut(head, |style| {
+        style.set_gap(Size {
+            width: LengthPercentage::length(GAP),
+            height: LengthPercentage::length(GAP),
+        });
+    });
+    let head_children = [
+        text(mason, true),
+        text(mason, true),
+        text(mason, true),
+        text(mason, true),
+    ];
+    mason.append_node(head, &head_children);
+
+    // .comment-text: block-level text
+    let body = text(mason, false);
+
+    let mut article_children = vec![head, body];
+    if let Some(child) = child {
+        let replies = flex(mason, FlexDirection::Column);
+        mason.with_style_mut(replies, |style| {
+            style.set_margin(Rect {
+                left: LengthPercentageAuto::length(INDENT),
+                right: LengthPercentageAuto::length(0.0),
+                top: LengthPercentageAuto::length(0.0),
+                bottom: LengthPercentageAuto::length(0.0),
+            });
+        });
+        mason.append_node(replies, &[child]);
+        article_children.push(replies);
+    }
+    mason.append_node(article, &article_children);
+    mason.append_node(host, &[article]);
+    host
+}
+
+/// Build the page: a width-pinned column root holding one deep chain plus a few
+/// shallow root comments, matching the fixture (15 comments, max depth 8).
+fn build(depth: usize, extra_roots: usize) -> (Mason, Id) {
+    let mut mason = Mason::new();
+    let root = flex(&mut mason, FlexDirection::Column);
+    mason.with_style_mut(root, |style| {
+        style.set_width(Dimension::length(SCREEN_W));
+    });
+
+    let list = flex(&mut mason, FlexDirection::Column);
+
+    let mut chain = None;
+    for _ in 0..depth {
+        chain = Some(comment(&mut mason, chain));
+    }
+    let mut roots = vec![chain.unwrap()];
+    for _ in 0..extra_roots {
+        roots.push(comment(&mut mason, None));
+    }
+    mason.append_node(list, &roots);
+    mason.append_node(root, &[list]);
+    (mason, root)
+}
+
+#[test]
+fn profile_hn_comment_thread_measure_volume() {
+    for zero in [0usize, 1] {
+        ZERO_INTRINSICS.store(zero, Ordering::Relaxed);
+        eprintln!(
+            "\n=== block text intrinsics: {} ===",
+            if zero == 1 { "ZERO (as observed on device)" } else { "correct" }
+        );
+        eprintln!("depth  measures   delta");
+        let mut prev = 0usize;
+        for depth in [1usize, 2, 4, 6, 8, 10] {
+            let (mut mason, root) = build(depth, 3);
+            MEASURES.store(0, Ordering::Relaxed);
+            mason.compute_wh(root, SCREEN_W, -2.0);
+            let n = MEASURES.load(Ordering::Relaxed);
+            eprintln!("{depth:>5}  {n:>8}   {}", n.saturating_sub(prev));
+            prev = n;
+        }
+    }
+}

--- a/crates/mason-core/tests/hn_comment_measure_volume.rs
+++ b/crates/mason-core/tests/hn_comment_measure_volume.rs
@@ -1,24 +1,8 @@
 //! Reproduce the HN comment thread's measure-callback volume in pure Rust.
 //!
-//! On device, one correct layout of a 15-comment / depth-8 thread issues
-//! **47,387** measure callbacks that resolve to only ~493 distinct layouts
-//! (~99% absorbed by the Kotlin measure cache). `deep_flex_profile.rs` models
-//! the same nesting with plain flex leaves and is *linear* — 31 calls per level,
-//! 310 at depth 10 — so the 100x gap comes from something that profile doesn't
-//! model.
-//!
-//! Difference under test: the real text leaves are `display: block` / `inline`
-//! (mason's own inline formatting path, `tree_inline.rs`), not measure-func
-//! leaves inside a flex row. This models the actual shape:
-//!
-//! ```text
-//! hn-comment            flex column
-//!   article.comment     flex column, padding 8
-//!     header            flex row, gap 8      <- 4 inline leaves
-//!     p.comment-text    block                <- long text leaf
-//!     section.replies   flex column, margin-left 12
-//!       hn-comment ...  (recursion)
-//! ```
+//! On device a depth-8 thread issued 47k measure callbacks; this test models the
+//! same nesting with inline/block text leaves so cache improvements can be
+//! validated without the full app.
 
 use mason_core::style::DisplayMode;
 use mason_core::*;

--- a/crates/mason-core/tests/nested_column_min_width.rs
+++ b/crates/mason-core/tests/nested_column_min_width.rs
@@ -1,0 +1,160 @@
+//! Repro for the HN comment-thread overflow: a wide, non-shrinkable flex ROW
+//! buried inside N nested column flex containers.
+//!
+//! Per CSS Flexbox §4.5, `min-width: auto` resolves to the content-based
+//! minimum size only on the *main* axis. For `flex-direction: column` the main
+//! axis is vertical, so a column flex item's *width* minimum is 0 and it should
+//! stretch to its container. The inner row should overflow its own box; the
+//! ancestors should stay at the container width.
+//!
+//! If the content-based minimum is being applied to the cross axis instead,
+//! every ancestor inflates to `row_width + sum(insets)` — which is exactly the
+//! staircase seen on device.
+
+use mason_core::*;
+use std::ffi::{c_float, c_longlong, c_void};
+
+const CONTAINER: f32 = 1000.0;
+const ITEM_W: f32 = 150.0;
+const ITEMS: usize = 4; // 4 * 150 = 600 wide row
+const PADDING: f32 = 20.0;
+const INDENT: f32 = 30.0;
+
+/// A leaf that refuses to be narrower than ITEM_W (like a short inline label).
+extern "C" fn measure_fixed(
+    _data: *const c_void,
+    known_width: c_float,
+    _known_height: c_float,
+    _available_width: c_float,
+    _available_height: c_float,
+) -> c_longlong {
+    let w = if known_width >= 0.0 {
+        known_width.max(ITEM_W)
+    } else {
+        ITEM_W
+    };
+    MeasureOutput::make(w, 20.0)
+}
+
+fn flex(mason: &mut Mason, direction: FlexDirection) -> Id {
+    let node = mason.create_node();
+    let id = node.id();
+    std::mem::forget(node);
+    mason.with_style_mut(id, |style| {
+        style.set_display(Display::Flex);
+        style.set_flex_direction(direction);
+    });
+    id
+}
+
+fn leaf(mason: &mut Mason) -> Id {
+    let node = mason.create_node();
+    let id = node.id();
+    std::mem::forget(node);
+    mason.set_measure(id, Some(measure_fixed), std::ptr::null_mut());
+    id
+}
+
+/// `.comment`: column box with padding, containing a wide row + optional replies.
+fn comment(mason: &mut Mason, child: Option<Id>) -> Id {
+    let host = flex(mason, FlexDirection::Column);
+
+    let article = flex(mason, FlexDirection::Column);
+    mason.with_style_mut(article, |style| {
+        style.set_padding(Rect {
+            left: LengthPercentage::length(PADDING),
+            right: LengthPercentage::length(PADDING),
+            top: LengthPercentage::length(PADDING),
+            bottom: LengthPercentage::length(PADDING),
+        });
+    });
+
+    // The wide, non-wrapping header row.
+    let head = flex(mason, FlexDirection::Row);
+    let head_children: Vec<Id> = (0..ITEMS).map(|_| leaf(mason)).collect();
+    mason.append_node(head, &head_children);
+
+    let mut article_children = vec![head];
+    if let Some(child) = child {
+        let replies = flex(mason, FlexDirection::Column);
+        mason.with_style_mut(replies, |style| {
+            style.set_margin(Rect {
+                left: LengthPercentageAuto::length(INDENT),
+                right: LengthPercentageAuto::length(0.0),
+                top: LengthPercentageAuto::length(0.0),
+                bottom: LengthPercentageAuto::length(0.0),
+            });
+        });
+        mason.append_node(replies, &[child]);
+        article_children.push(replies);
+    }
+    mason.append_node(article, &article_children);
+    mason.append_node(host, &[article]);
+    host
+}
+
+#[test]
+fn nested_column_items_should_not_inflate_past_container() {
+    for depth in [1usize, 2, 4, 8] {
+        let mut mason = Mason::new();
+        let root = flex(&mut mason, FlexDirection::Column);
+        // Definite root width. Without this the root is auto-sized and sizing
+        // it to content is correct taffy behaviour, not a bug — the app's real
+        // root has `width: 100%`, so pin it here too.
+        mason.with_style_mut(root, |style| {
+            style.set_width(Dimension::length(CONTAINER));
+        });
+
+        let mut nested = None;
+        for _ in 0..depth {
+            nested = Some(comment(&mut mason, nested));
+        }
+        mason.append_node(root, &[nested.unwrap()]);
+
+        // Definite container width, unconstrained height — same as the app's
+        // computeAndLayout(1080, -2).
+        mason.compute_wh(root, CONTAINER, -2.0);
+
+        let root_w = mason.layout_raw(root).size.width;
+        let outer_w = mason.layout_raw(nested.unwrap()).size.width;
+        let expected_row = ITEM_W * ITEMS as f32;
+
+        eprintln!(
+            "depth={depth} root_w={root_w} outermost_comment_w={outer_w} \
+             (container={CONTAINER}, inner row needs {expected_row})"
+        );
+
+        assert!(
+            outer_w <= CONTAINER + 0.5,
+            "depth={depth}: outermost column box is {outer_w}, wider than the \
+             {CONTAINER} container — the inner row's content-based minimum is \
+             inflating the cross axis of every ancestor"
+        );
+    }
+}
+
+#[test]
+fn default_align_items_should_be_stretch_not_start() {
+    let mut mason = Mason::new();
+    let root = flex(&mut mason, FlexDirection::Column);
+    mason.with_style_mut(root, |style| {
+        style.set_width(Dimension::length(CONTAINER));
+    });
+    let child = flex(&mut mason, FlexDirection::Column);
+    let l = leaf(&mut mason);
+    mason.append_node(child, &[l]);
+    mason.append_node(root, &[child]);
+
+    let mut align = None;
+    mason.with_style(root, |s| { align = s.get_align_items(); });
+    eprintln!("default align_items on a flex container = {align:?}");
+
+    mason.compute_wh(root, CONTAINER, -2.0);
+    let cl = mason.layout_raw(child);
+    eprintln!("child: x={} w={} (container={CONTAINER})", cl.location.x, cl.size.width);
+
+    assert_eq!(
+        cl.size.width, CONTAINER,
+        "a column flex item with align-items:normal must stretch to the container width"
+    );
+}

--- a/crates/mason-core/tests/nested_column_min_width.rs
+++ b/crates/mason-core/tests/nested_column_min_width.rs
@@ -1,15 +1,7 @@
-//! Repro for the HN comment-thread overflow: a wide, non-shrinkable flex ROW
-//! buried inside N nested column flex containers.
-//!
-//! Per CSS Flexbox §4.5, `min-width: auto` resolves to the content-based
-//! minimum size only on the *main* axis. For `flex-direction: column` the main
-//! axis is vertical, so a column flex item's *width* minimum is 0 and it should
-//! stretch to its container. The inner row should overflow its own box; the
-//! ancestors should stay at the container width.
-//!
-//! If the content-based minimum is being applied to the cross axis instead,
-//! every ancestor inflates to `row_width + sum(insets)` — which is exactly the
-//! staircase seen on device.
+//! Regression: a wide row inside nested column flex containers should not
+//! inflate every ancestor's width. `min-width: auto` applies only on the main
+//! axis, so a column item's width minimum is 0 and it should stretch to the
+//! container.
 
 use mason_core::*;
 use std::ffi::{c_float, c_longlong, c_void};
@@ -98,9 +90,7 @@ fn nested_column_items_should_not_inflate_past_container() {
     for depth in [1usize, 2, 4, 8] {
         let mut mason = Mason::new();
         let root = flex(&mut mason, FlexDirection::Column);
-        // Definite root width. Without this the root is auto-sized and sizing
-        // it to content is correct taffy behaviour, not a bug — the app's real
-        // root has `width: 100%`, so pin it here too.
+        // Pin the root width like the app does with `width: 100%`.
         mason.with_style_mut(root, |style| {
             style.set_width(Dimension::length(CONTAINER));
         });
@@ -126,9 +116,7 @@ fn nested_column_items_should_not_inflate_past_container() {
 
         assert!(
             outer_w <= CONTAINER + 0.5,
-            "depth={depth}: outermost column box is {outer_w}, wider than the \
-             {CONTAINER} container — the inner row's content-based minimum is \
-             inflating the cross axis of every ancestor"
+            "depth={depth}: outermost column box is {outer_w}, wider than {CONTAINER}"
         );
     }
 }

--- a/crates/mason-core/tests/style_arena_cow_leak.rs
+++ b/crates/mason-core/tests/style_arena_cow_leak.rs
@@ -1,16 +1,6 @@
-//! Does a style write on one node leak into another node that was interned
-//! into the same arena slot?
-//!
-//! Two freshly-created nodes have identical (default) styles, so the hash-
-//! deduping style arena can hand them the same slot. Mutating one must
-//! copy-on-write it out of that slot; if the write lands in the shared slot
-//! instead, the second node silently inherits it.
-//!
-//! Motivating symptom: an `hn-comment` host in the demo comes out of layout
-//! with `align-items: center` that no CSS rule sets and no TS setter ever
-//! wrote, in the combination (flex-direction: column + align-items: center) -
-//! which is what you get if a node inherits `center` from a `.comment-head`
-//! sibling-slot and then COWs when its own `flex-direction` is written.
+//! Regression: a style write on one node must not leak into another node that
+//! shares the same interned arena slot. The style arena dedupes identical
+//! styles; mutating one must copy-on-write it to a private slot first.
 
 use mason_core::*;
 
@@ -33,12 +23,12 @@ fn align_items_of(mason: &mut Mason, id: Id) -> Option<AlignItems> {
 fn write_on_one_node_does_not_leak_into_an_identically_styled_node() {
     let mut mason = Mason::new();
 
-    // Two nodes with identical styles - candidates for interning.
+    // Two nodes with identical default styles may share an arena slot.
     let a = node(&mut mason);
     let b = node(&mut mason);
 
-    assert_eq!(align_items_of(&mut mason, a), None, "a starts unset");
-    assert_eq!(align_items_of(&mut mason, b), None, "b starts unset");
+    assert_eq!(align_items_of(&mut mason, a), None);
+    assert_eq!(align_items_of(&mut mason, b), None);
 
     // Mutate only `a`.
     mason.with_style_mut(a, |style| {
@@ -63,8 +53,6 @@ fn write_on_one_node_does_not_leak_into_an_identically_styled_node() {
 fn cow_after_a_leaked_write_does_not_carry_the_leak() {
     let mut mason = Mason::new();
 
-    // Mirrors the real tree: a `.comment-head` (row + center) and an
-    // `hn-comment` host (column, no align-items) created as defaults first.
     let head = node(&mut mason);
     let host = node(&mut mason);
 
@@ -74,8 +62,6 @@ fn cow_after_a_leaked_write_does_not_carry_the_leak() {
         style.set_align_items(Some(AlignItems::CENTER));
     });
 
-    // Now give the host its own (different) style. If the host was sharing a
-    // slot that `head` mutated, this COW copies the poisoned slot.
     mason.with_style_mut(host, |style| {
         style.set_display(Display::Flex);
         style.set_flex_direction(FlexDirection::Column);
@@ -84,7 +70,6 @@ fn cow_after_a_leaked_write_does_not_carry_the_leak() {
     assert_eq!(
         align_items_of(&mut mason, host),
         None,
-        "host only ever set display + flex-direction, but came out with \
-         align-items - exactly the (column + center) combination seen on device"
+        "host should not inherit align-items from a shared arena slot"
     );
 }

--- a/crates/mason-core/tests/style_arena_cow_leak.rs
+++ b/crates/mason-core/tests/style_arena_cow_leak.rs
@@ -1,0 +1,90 @@
+//! Does a style write on one node leak into another node that was interned
+//! into the same arena slot?
+//!
+//! Two freshly-created nodes have identical (default) styles, so the hash-
+//! deduping style arena can hand them the same slot. Mutating one must
+//! copy-on-write it out of that slot; if the write lands in the shared slot
+//! instead, the second node silently inherits it.
+//!
+//! Motivating symptom: an `hn-comment` host in the demo comes out of layout
+//! with `align-items: center` that no CSS rule sets and no TS setter ever
+//! wrote, in the combination (flex-direction: column + align-items: center) -
+//! which is what you get if a node inherits `center` from a `.comment-head`
+//! sibling-slot and then COWs when its own `flex-direction` is written.
+
+use mason_core::*;
+
+fn node(mason: &mut Mason) -> Id {
+    let n = mason.create_node();
+    let id = n.id();
+    std::mem::forget(n);
+    id
+}
+
+fn align_items_of(mason: &mut Mason, id: Id) -> Option<AlignItems> {
+    let mut out = None;
+    mason.with_style(id, |s| {
+        out = s.get_align_items();
+    });
+    out
+}
+
+#[test]
+fn write_on_one_node_does_not_leak_into_an_identically_styled_node() {
+    let mut mason = Mason::new();
+
+    // Two nodes with identical styles - candidates for interning.
+    let a = node(&mut mason);
+    let b = node(&mut mason);
+
+    assert_eq!(align_items_of(&mut mason, a), None, "a starts unset");
+    assert_eq!(align_items_of(&mut mason, b), None, "b starts unset");
+
+    // Mutate only `a`.
+    mason.with_style_mut(a, |style| {
+        style.set_display(Display::Flex);
+        style.set_flex_direction(FlexDirection::Row);
+        style.set_align_items(Some(AlignItems::CENTER));
+    });
+
+    assert_eq!(
+        align_items_of(&mut mason, a),
+        Some(AlignItems::CENTER),
+        "a should have the value we just set"
+    );
+    assert_eq!(
+        align_items_of(&mut mason, b),
+        None,
+        "b never had align-items set - a's write leaked across an interned slot"
+    );
+}
+
+#[test]
+fn cow_after_a_leaked_write_does_not_carry_the_leak() {
+    let mut mason = Mason::new();
+
+    // Mirrors the real tree: a `.comment-head` (row + center) and an
+    // `hn-comment` host (column, no align-items) created as defaults first.
+    let head = node(&mut mason);
+    let host = node(&mut mason);
+
+    mason.with_style_mut(head, |style| {
+        style.set_display(Display::Flex);
+        style.set_flex_direction(FlexDirection::Row);
+        style.set_align_items(Some(AlignItems::CENTER));
+    });
+
+    // Now give the host its own (different) style. If the host was sharing a
+    // slot that `head` mutated, this COW copies the poisoned slot.
+    mason.with_style_mut(host, |style| {
+        style.set_display(Display::Flex);
+        style.set_flex_direction(FlexDirection::Column);
+    });
+
+    assert_eq!(
+        align_items_of(&mut mason, host),
+        None,
+        "host only ever set display + flex-direction, but came out with \
+         align-items - exactly the (column + center) combination seen on device"
+    );
+}


### PR DESCRIPTION
## What changed

- Added `crates/mason-core/src/layout_cache.rs`: a drop-in replacement for taffy's fixed 9-slot `Cache`.
- Wired the new cache into `Node` (`crates/mason-core/src/node.rs`) and added `mod layout_cache` in `crates/mason-core/src/lib.rs`.
- Fixed an Apple style-buffer exposure bug in `lib.rs`: `style_data` and `node_state_data` now call `style_mut()` before handing the buffer to platform code, preventing writes into shared arena slots from leaking to other nodes.
- Added regression/performance tests:
  - `deep_flex_profile.rs`
  - `hn_comment_measure_volume.rs`
  - `nested_column_min_width.rs`
  - `style_arena_cow_leak.rs`

## Why

Taffy's cache hashes `MaxContent` and every `Definite(_)` width into the same slot. For nested text/inline nodes that are probed alternately at min-content, max-content, and a definite width, each probe evicts the previous one. The miss compounds per nesting level and caused single text nodes to be measured thousands of times in deep comment threads.

The new cache keeps taffy's exact matching semantics but stores entries by their own inputs, so distinct constraints coexist up to a bounded capacity (32). This eliminates the probe-thrashing without changing layout results.

## Validation

- `cargo test -p mason-core` passes.
- `cargo test -p mason-core --test hn_comment_measure_volume` passes.

## Notes / follow-up

- The Apple style-buffer COW fix was co-located here because the same HN-thread repro surfaced it; it could be extracted separately if reviewers prefer.
- `style_arena_cow_leak.rs` and `nested_column_min_width.rs` are correctness regressions that happen to be exercised by the same fixture; keeping them with the cache PR prevents the cache work from masking the underlying bugs.