### PR TITLE
fix: box Node.state buffer to prevent use-after-free on SlotMap reallocation

### DIFF
--- a/crates/mason-core/src/lib.rs
+++ b/crates/mason-core/src/lib.rs
@@ -1800,4 +1800,39 @@ mod tests {
             expected
         );
     }
+
+    /// Regression: the per-node state buffer is handed to platform code as a raw
+    /// pointer (a direct ByteBuffer on Android) and cached, so its address must
+    /// stay stable when the tree's SlotMap reallocates on growth.
+    #[test]
+    fn node_state_buffer_stable_across_tree_growth() {
+        use crate::node::{NodeStateKeys, NODE_STATE_BUFFER_SIZE};
+
+        let mut mason = Mason::new();
+        let first = mason.create_node();
+        let first_id = first.id();
+
+        let (ptr_before, len) = mason.node_state_data_raw_mut(first_id);
+        assert!(!ptr_before.is_null());
+        assert_eq!(len, NODE_STATE_BUFFER_SIZE);
+
+        unsafe {
+            *ptr_before.add(NodeStateKeys::IS_VIRTUAL as usize) = 1;
+        }
+
+        // Grow past the SlotMap's initial capacity to force reallocation.
+        let mut nodes = Vec::new();
+        for _ in 0..4096 {
+            nodes.push(mason.create_node());
+        }
+
+        let (ptr_after, len_after) = mason.node_state_data_raw(first_id);
+        assert_eq!(len_after, NODE_STATE_BUFFER_SIZE);
+        assert_eq!(
+            ptr_before, ptr_after as *mut u8,
+            "state buffer address changed after tree growth"
+        );
+        let sentinel = unsafe { *ptr_after.add(NodeStateKeys::IS_VIRTUAL as usize) };
+        assert_eq!(sentinel, 1, "state buffer contents lost after tree growth");
+    }
 }

--- a/crates/mason-core/src/node.rs
+++ b/crates/mason-core/src/node.rs
@@ -515,7 +515,9 @@ pub struct Node {
     pub(crate) has_measure: bool,
     pub(crate) type_: NodeType,
     pub(crate) is_anonymous: bool,
-    pub(crate) state: [u8; NODE_STATE_BUFFER_SIZE],
+    // Boxed because platform code maps this buffer as a raw pointer and caches it;
+    // the pointee must not move when the SlotMap reallocates.
+    pub(crate) state: Box<[u8; NODE_STATE_BUFFER_SIZE]>,
     // optional per-node pseudo styles (hover/active/focus/disabled/checked)
     pub(crate) pseudo_styles: Option<PseudoStyles>,
     #[cfg(target_os = "android")]
@@ -534,7 +536,7 @@ impl Node {
             has_measure: false,
             type_: NodeType::Normal,
             is_anonymous: false,
-            state: [0u8; NODE_STATE_BUFFER_SIZE],
+            state: Box::new([0u8; NODE_STATE_BUFFER_SIZE]),
             pseudo_styles: None,
             #[cfg(target_os = "android")]
             state_buffer: -1,
@@ -552,7 +554,7 @@ impl Node {
             has_measure: false,
             type_: NodeType::Normal,
             is_anonymous: false,
-            state: [0u8; NODE_STATE_BUFFER_SIZE],
+            state: Box::new([0u8; NODE_STATE_BUFFER_SIZE]),
             pseudo_styles: None,
             #[cfg(target_os = "android")]
             state_buffer: -1,


### PR DESCRIPTION

## What changed

- `crates/mason-core/src/node.rs`

  - Changed `Node.state` from an inline `[u8; NODE_STATE_BUFFER_SIZE]` to `Box<[u8; NODE_STATE_BUFFER_SIZE]>`.
  - The pointer to the buffer stays stable when the `SlotMap` reallocates, because the `Box` itself moves but the heap-allocated array does not.
- `crates/mason-core/src/lib.rs`

  - Added regression test `node_state_buffer_stable_across_tree_growth` that fails on the old inline array and passes on the boxed one.

## Why

`Mason::new` creates the node tree with capacity 128. Once the tree grows past that, the `SlotMap` reallocates and every `Node` moves. Kotlin cached a `DirectByteBuffer` over `state.as_mut_ptr()`; after reallocation that pointer dangled, so writing the state buffer corrupted freed memory. Style buffers already avoided this by living in a boxed arena; the state buffer did not.