### PR TITLE
fix(scroll): prevent unnecessary clipping when scrolling is disabled

### DIFF
--- a/packages/nativescript-masonkit/src-native/mason-android/masonkit/src/main/java/org/nativescript/mason/masonkit/Scroll.kt
+++ b/packages/nativescript-masonkit/src-native/mason-android/masonkit/src/main/java/org/nativescript/mason/masonkit/Scroll.kt
@@ -112,6 +112,8 @@ class Scroll @JvmOverloads constructor(
   }
 
   private fun clipScrollViewport(canvas: Canvas) {
+    if (!enableScrollX && !enableScrollY) return
+
     val left = scrollX + paddingLeft
     val top = scrollY + paddingTop
     val right = scrollX + width - paddingRight


### PR DESCRIPTION
<img width="408" height="216" alt="download" src="https://github.com/user-attachments/assets/c5a5e412-9743-48f5-94b3-c03f28381d05" />
<img width="412" height="214" alt="image" src="https://github.com/user-attachments/assets/c73be2b5-6265-4f99-965f-f4bd8fece135" />
