### PR TITLE
perf(core): reduce layout memory and repeated work

### DIFF
--- a/crates/mason-core/src/lib.rs
+++ b/crates/mason-core/src/lib.rs
@@ -447,7 +447,7 @@ impl Mason {
             .get_mut(node)
             .and_then(|node| {
                 if node.pseudo_styles.is_none() {
-                    node.pseudo_styles = Some(node::PseudoStyles::default());
+                    node.pseudo_styles = Some(Box::new(node::PseudoStyles::default()));
                 }
                 node.pseudo_styles
                     .as_mut()
@@ -481,7 +481,7 @@ impl Mason {
             .get_mut(node)
             .and_then(|node| {
                 if node.pseudo_styles.is_none() {
-                    node.pseudo_styles = Some(node::PseudoStyles::default());
+                    node.pseudo_styles = Some(Box::new(node::PseudoStyles::default()));
                 }
                 node.pseudo_styles
                     .as_mut()
@@ -498,7 +498,7 @@ impl Mason {
     pub fn pseudo_style_handle_mut(&mut self, node: Id, flags: u16) -> Option<u32> {
         self.0.nodes_mut().get_mut(node).and_then(|node| {
             if node.pseudo_styles.is_none() {
-                node.pseudo_styles = Some(crate::node::PseudoStyles::default());
+                node.pseudo_styles = Some(Box::new(crate::node::PseudoStyles::default()));
             }
             node.pseudo_styles
                 .as_mut()
@@ -516,7 +516,7 @@ impl Mason {
             .get_mut(node)
             .and_then(|node| {
                 if node.pseudo_styles.is_none() {
-                    node.pseudo_styles = Some(crate::node::PseudoStyles::default());
+                    node.pseudo_styles = Some(Box::new(crate::node::PseudoStyles::default()));
                 }
                 node.pseudo_styles
                     .as_mut()
@@ -1050,7 +1050,7 @@ impl Mason {
         }
 
         if node.pseudo_styles.is_none() {
-            node.pseudo_styles = Some(crate::node::PseudoStyles::default());
+            node.pseudo_styles = Some(Box::new(crate::node::PseudoStyles::default()));
         }
         let base = node.style.clone();
         let p = node.pseudo_styles.as_mut().unwrap();

--- a/crates/mason-core/src/node.rs
+++ b/crates/mason-core/src/node.rs
@@ -505,6 +505,13 @@ impl InlineMeasureCache {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SubtreeAnalysis {
+    pub(crate) has_children: bool,
+    pub(crate) has_mixed_content: bool,
+    pub(crate) all_inline: bool,
+}
+
 #[derive(Debug, Clone)]
 pub struct Node {
     pub(crate) style: Style,
@@ -512,6 +519,7 @@ pub struct Node {
     /// evicting each other through taffy's fixed 9-slot cache.
     pub(crate) cache: LayoutCache,
     pub(crate) inline_measure_cache: InlineMeasureCache,
+    pub(crate) subtree_analysis: Option<SubtreeAnalysis>,
     pub(crate) unrounded_layout: Layout,
     pub(crate) final_layout: Layout,
     pub(crate) guard: Arc<()>,
@@ -533,6 +541,7 @@ impl Node {
             style: Style::new(arena),
             cache: Default::default(),
             inline_measure_cache: InlineMeasureCache::new(),
+            subtree_analysis: None,
             unrounded_layout: Default::default(),
             final_layout: Default::default(),
             guard: Default::default(),
@@ -551,6 +560,7 @@ impl Node {
             style: Style::new_with_handle(arena, handle),
             cache: Default::default(),
             inline_measure_cache: InlineMeasureCache::new(),
+            subtree_analysis: None,
             unrounded_layout: Default::default(),
             final_layout: Default::default(),
             guard: Default::default(),
@@ -659,6 +669,7 @@ impl Node {
     pub fn mark_dirty(&mut self) -> ClearState {
         self.set_node_state(true);
         self.inline_measure_cache.clear();
+        self.subtree_analysis = None;
         self.cache.clear()
     }
 

--- a/crates/mason-core/src/node.rs
+++ b/crates/mason-core/src/node.rs
@@ -522,7 +522,7 @@ pub struct Node {
     // the pointee must not move when the SlotMap reallocates.
     pub(crate) state: Box<[u8; NODE_STATE_BUFFER_SIZE]>,
     // optional per-node pseudo styles (hover/active/focus/disabled/checked)
-    pub(crate) pseudo_styles: Option<PseudoStyles>,
+    pub(crate) pseudo_styles: Option<Box<PseudoStyles>>,
     #[cfg(target_os = "android")]
     pub(crate) state_buffer: jni::sys::jint,
 }
@@ -568,7 +568,7 @@ impl Node {
     /// The `style` should have been created with the same arena as the node.
     pub fn set_pseudo_style(&mut self, state: PseudoStates, style: Style) {
         if self.pseudo_styles.is_none() {
-            self.pseudo_styles = Some(PseudoStyles::default())
+            self.pseudo_styles = Some(Box::new(PseudoStyles::default()))
         }
         if let Some(p) = &mut self.pseudo_styles {
             if state.contains(PseudoStates::HOVER) {

--- a/crates/mason-core/src/tree.rs
+++ b/crates/mason-core/src/tree.rs
@@ -956,13 +956,6 @@ impl Tree {
 
         if use_rounding {
             round_layout(self, root);
-        } else {
-            // Ensure final_layout mirrors unrounded_layout so prints / consumers that read
-            // final_layout get the correct positions even when rounding is disabled.
-            let mut nodes = self.nodes_mut();
-            for (_id, node) in nodes.iter_mut() {
-                node.final_layout = node.unrounded_layout;
-            }
         }
     }
 
@@ -2533,7 +2526,13 @@ impl PrintTree for Tree {
 
     #[inline(always)]
     fn get_final_layout(&self, node_id: NodeId) -> Layout {
-        self.nodes()[node_id.into()].final_layout
+        let inner = self.inner();
+        let node = &inner.nodes[node_id.into()];
+        if inner.use_rounding {
+            node.final_layout
+        } else {
+            node.unrounded_layout
+        }
     }
 }
 
@@ -2582,6 +2581,24 @@ pub fn print_tree(tree: &impl PrintTree, root: NodeId) {
             let has_sibling = index < num_children - 1;
             print_node(tree, child, has_sibling, new_string.clone());
         }
+    }
+}
+
+#[cfg(test)]
+mod print_tree_tests {
+    use super::*;
+
+    #[test]
+    fn final_layout_respects_the_rounding_mode() {
+        let mut tree = Tree::new();
+        let node = tree.create_node();
+        let node_id = NodeId::from(node.id());
+        tree.node_from_id_mut(node_id).unrounded_layout.size.width = 1.0;
+        tree.node_from_id_mut(node_id).final_layout.size.width = 2.0;
+
+        assert_eq!(PrintTree::get_final_layout(&tree, node_id).size.width, 1.0);
+        tree.set_use_rounding(true);
+        assert_eq!(PrintTree::get_final_layout(&tree, node_id).size.width, 2.0);
     }
 }
 

--- a/crates/mason-core/src/tree.rs
+++ b/crates/mason-core/src/tree.rs
@@ -1,4 +1,4 @@
-use crate::node::{drain_deferred_cleanup, Node, NodeData, NodeRef, NodeType};
+use crate::node::{drain_deferred_cleanup, Node, NodeData, NodeRef, NodeType, SubtreeAnalysis};
 use crate::style::arena::{StyleArena, StyleHandle, STYLE_BUFFER_SIZE};
 use crate::style::style_guard::StyleGuard;
 use crate::style::{DisplayMode, Style};
@@ -32,13 +32,6 @@ impl From<NodeId> for Id {
     fn from(value: NodeId) -> Self {
         KeyData::from_ffi(value.into()).into()
     }
-}
-
-#[derive(Clone, Copy, Debug)]
-struct SubtreeAnalysis {
-    has_children: bool,
-    has_mixed_content: bool,
-    all_inline: bool,
 }
 
 #[derive(Debug)]
@@ -849,13 +842,16 @@ impl Tree {
         RwLockReadGuard::map(self.0.read(), |v| v.children.get(node_id).unwrap())
     }
 
-    fn analyze_subtree(&self, id: Id) -> SubtreeAnalysis {
+    fn analyze_subtree(&mut self, id: Id) -> SubtreeAnalysis {
+        let mut inner = self.inner_mut();
+        if let Some(analysis) = inner.nodes.get(id).and_then(|node| node.subtree_analysis) {
+            return analysis;
+        }
+
         let mut has_children = false;
         let mut has_mixed_content = false;
         let mut all_inline = true;
 
-        // Hold a single read lock for entire analysis instead of re-acquiring per child
-        let inner = self.inner();
         if let Some(children) = inner.children.get(id) {
             has_children = !children.is_empty();
 
@@ -891,11 +887,15 @@ impl Tree {
             }
         }
 
-        SubtreeAnalysis {
+        let analysis = SubtreeAnalysis {
             has_children,
             has_mixed_content,
             all_inline,
+        };
+        if let Some(node) = inner.nodes.get_mut(id) {
+            node.subtree_analysis = Some(analysis);
         }
+        analysis
     }
 
     pub fn compute_layout(
@@ -2599,6 +2599,27 @@ mod print_tree_tests {
         assert_eq!(PrintTree::get_final_layout(&tree, node_id).size.width, 1.0);
         tree.set_use_rounding(true);
         assert_eq!(PrintTree::get_final_layout(&tree, node_id).size.width, 2.0);
+    }
+
+    #[test]
+    fn subtree_analysis_cache_is_invalidated_by_child_changes() {
+        let mut tree = Tree::new();
+        let parent = tree.create_node();
+        let child = tree.create_node();
+        tree.with_style_mut(child.id(), |style| {
+            style.set_display_mode(DisplayMode::Inline)
+        });
+        tree.append(parent.id(), child.id());
+
+        assert!(tree.analyze_subtree(parent.id()).all_inline);
+        assert!(tree.inner().nodes[parent.id()].subtree_analysis.is_some());
+
+        tree.with_style_mut(child.id(), |style| {
+            style.set_display_mode(DisplayMode::ListItem)
+        });
+
+        assert!(tree.inner().nodes[parent.id()].subtree_analysis.is_none());
+        assert!(!tree.analyze_subtree(parent.id()).all_inline);
     }
 }
 

--- a/crates/mason-core/src/tree_inline.rs
+++ b/crates/mason-core/src/tree_inline.rs
@@ -1204,6 +1204,8 @@ impl Tree {
             return Some(Size::ZERO);
         }
 
+        let fallback_metrics = self.get_font_metrics(child_id);
+
         #[cfg(test)]
         let _ = (child_id, available_width, segments.len());
 
@@ -1237,8 +1239,7 @@ impl Tree {
                                 max_line_width = max_line_width.max(current_line_width);
                                 let (a, d) =
                                     if current_line_ascent == 0.0 && current_line_descent == 0.0 {
-                                        let m = self.get_font_metrics(child_id);
-                                        (m.ascent, m.descent)
+                                        (fallback_metrics.ascent, fallback_metrics.descent)
                                     } else {
                                         (current_line_ascent, current_line_descent)
                                     };
@@ -1257,8 +1258,7 @@ impl Tree {
                                 max_line_width = max_line_width.max(current_line_width);
                                 let (a, d) =
                                     if current_line_ascent == 0.0 && current_line_descent == 0.0 {
-                                        let m = self.get_font_metrics(child_id);
-                                        (m.ascent, m.descent)
+                                        (fallback_metrics.ascent, fallback_metrics.descent)
                                     } else {
                                         (current_line_ascent, current_line_descent)
                                     };
@@ -1282,8 +1282,7 @@ impl Tree {
                             max_line_width = max_line_width.max(current_line_width);
                             let (a, d) =
                                 if current_line_ascent == 0.0 && current_line_descent == 0.0 {
-                                    let m = self.get_font_metrics(child_id);
-                                    (m.ascent, m.descent)
+                                    (fallback_metrics.ascent, fallback_metrics.descent)
                                 } else {
                                     (current_line_ascent, current_line_descent)
                                 };
@@ -1301,8 +1300,7 @@ impl Tree {
                 InlineSegment::LineBreak => {
                     max_line_width = max_line_width.max(current_line_width);
                     let (a, d) = if current_line_ascent == 0.0 && current_line_descent == 0.0 {
-                        let m = self.get_font_metrics(child_id);
-                        (m.ascent, m.descent)
+                        (fallback_metrics.ascent, fallback_metrics.descent)
                     } else {
                         (current_line_ascent, current_line_descent)
                     };
@@ -1318,8 +1316,7 @@ impl Tree {
         max_line_width = max_line_width.max(current_line_width);
         if current_line_width > 0.0 || !segments.is_empty() {
             let (a, d) = if current_line_ascent == 0.0 && current_line_descent == 0.0 {
-                let m = self.get_font_metrics(child_id);
-                (m.ascent, m.descent)
+                (fallback_metrics.ascent, fallback_metrics.descent)
             } else {
                 (current_line_ascent, current_line_descent)
             };

--- a/crates/mason-core/src/tree_inline.rs
+++ b/crates/mason-core/src/tree_inline.rs
@@ -2452,15 +2452,10 @@ impl Tree {
                 }
             }
 
-            // Now get segments (freshly populated by the measure call above)
-            let segments = {
-                let nd = self.node_data();
-                let node_data = nd.get(id).unwrap();
-                let guard = node_data.inline_segments();
-                let vec = guard.to_vec();
-                drop(guard);
-                vec
-            };
+            // Read freshly-populated segments without cloning them.
+            let nd = self.node_data();
+            let node_data = nd.get(id).unwrap();
+            let segments = node_data.inline_segments();
 
             // If there are children, IFC is needed for placement. For direct text-only
             // segments, use IFC only when native measurement did not provide a size.
@@ -2470,7 +2465,7 @@ impl Tree {
                 let mut prepared_items: Vec<PreparedItem> = Vec::new();
 
                 // Build prepared items from segments (which include text and inline children)
-                for segment in &segments {
+                for segment in segments.iter() {
                     match segment {
                         InlineSegment::Text {
                             width,
@@ -2521,6 +2516,8 @@ impl Tree {
                         }
                     }
                 }
+                drop(segments);
+                drop(nd);
 
                 // If no segments but we have children, add children directly
                 if prepared_items.is_empty() {
@@ -2642,6 +2639,9 @@ impl Tree {
                         }
                     }
                 }
+            } else {
+                drop(segments);
+                drop(nd);
             }
 
             // For scroll/overflow containers, preserve the content_size from
@@ -2703,16 +2703,14 @@ impl Tree {
             return ret;
         }
 
-        let segments = {
+        let has_segments = {
             let nd = self.node_data();
             let node_data = nd.get(id).unwrap();
-            let guard = node_data.inline_segments();
-            let vec = guard.to_vec();
-            drop(guard);
-            vec
+            let has_segments = !node_data.inline_segments().is_empty();
+            has_segments
         };
 
-        if flow_child_ids.is_empty() && segments.is_empty() {
+        if flow_child_ids.is_empty() && !has_segments {
             let leaf_output = if has_measure {
                 let measure = self.node_data().get(id).unwrap().copy_measure();
                 compute_leaf_layout(
@@ -2762,8 +2760,11 @@ impl Tree {
 
         let mut prepared_items: Vec<PreparedItem> = Vec::new();
 
-        if !segments.is_empty() && flow_child_ids.is_empty() {
-            for segment in &segments {
+        if has_segments && flow_child_ids.is_empty() {
+            let nd = self.node_data();
+            let node_data = nd.get(id).unwrap();
+            let segments = node_data.inline_segments();
+            for segment in segments.iter() {
                 match segment {
                     InlineSegment::Text {
                         width,


### PR DESCRIPTION
## Summary

This PR applies six small, focused optimizations to Mason's core layout paths.

Together they reduce per-node memory use and avoid repeated subtree analysis,
font-metric lookups, inline-segment cloning, layout mirroring, and tree locks.

## Overall results

Compared with `upstream/chore/perf-improvements` on the Android deep-layout
benchmark:

- Cold layout: 5.5% faster
- Export and apply layout: 5.0% faster
- Alternating-width layout: 2.1% faster
- Style mutation relayout: 1.8% faster
- Fixture construction: 0.4% faster
- Text mutation relayout: 1.4% faster
- Median PSS across phases: approximately 0.44 MiB lower

The comparison used 5 runs, 5 samples per run, and 12 inner iterations on
`emulator-5554`, alternating baseline and candidate execution order.

## Changes and isolated results

| Commit | Change | Isolated result |
|---|---|---|
| `dac3392a` | Allocate pseudo styles only when needed | Saves approximately 1.5 KB per ordinary node; fixture PSS was 0.5–1.2 MiB lower, with build 2.6% faster |
| `d16766ca` | Remove the redundant full-tree final-layout mirror | Text relayout 9.8% faster and fixture build 3.0% faster; other timing phases were mixed |
| `dd105021` | Cache subtree analysis with dirty-state invalidation | Alternating layout 5.0%, text relayout 4.5%, style relayout 1.7%, and cold layout 1.5% faster |
| `c3c40a05` | Hoist inline font metrics lookup out of the wrapping loop | Text relayout 5.6%, cold layout 2.9%, and alternating layout 2.6% faster |
| `d43070f3` | Avoid cloning inline segments during layout passes | Text relayout 4.8%, alternating layout 3.1%, and cold layout 2.6% faster |

## Testing

- `cargo test -p mason-core`
- Android release benchmark against `upstream/chore/perf-improvements`
- All benchmark APK builds and 10 emulator runs completed successfully